### PR TITLE
Kovacsm reticulate flow fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nuvolos
 Type: Package
 Title: R connector to Nuvolos 
-Version: 0.1.3
+Version: 0.1.4
 Author: Alphacruncher AG
 Maintainer: Andras Sali <andras.sali@alphacruncher.com>
 Description: Functions to work with nuvolos.cloud data through R.


### PR DESCRIPTION
We have encountered an error if the user has never used the r-connector package before: miniconda is not installed for reticulate and thus the user will not be able to proceed installing the dependencies of the connector.

I set up a fix where if we get an error installing the dependency we try to install miniconda. The issue is that you cannot proceed immediately after installing miniconda as reticulate does not find miniconda without an R session restart. The R session cannot be properly restarted from inside R without user interaction, so we ask the user to do the restart manually.

So the flow should be:

1 if miniconda is there and the nuvolos@pip is there, import nuvolos
2 if miniconda is there and nuvolos@pip is not there, pip install nuvolos
3 if miniconda is not there: install miniconda, ask the user to restart R, then repeat previous command which will jump to 2

@pibence Please clean up your home folder and try the flow above
@andrewsali please review - I don't want to merge before @pibence tested this of course