### PR TITLE
Pipisb/reticulate new

### DIFF
--- a/R/sql_methods.R
+++ b/R/sql_methods.R
@@ -112,8 +112,6 @@ to_sql <- function(df,
   
   username <- NULL
   password <- NULL
-  index <- reticulate::r_to_py(index)
-  nanoseconds <- reticulate::r_to_py(nanoseconds) 
 
   # reading credentials for establishing connection
   conn_param <- get_credentials(username, password, dbname, schemaname)

--- a/R/sql_methods.R
+++ b/R/sql_methods.R
@@ -203,6 +203,11 @@ import_nuvolos <- function(){
   nuvolos <- tryCatch({
     reticulate::import("nuvolos")
   }, error = function(e){
+    # checking environment variable to make sure it is set as TRUE, otherwise miniconda installer prompt won't be shown
+    if (Sys.getenv("RETICULATE_MINICONDA_ENABLED")==FALSE){
+      Sys.setenv("RETICULATE_MINICONDA_ENABLED" = TRUE)
+    }
+    # installing and importing nuvolos package
     reticulate::py_install("nuvolos", pip = TRUE)
     return(reticulate::import("nuvolos"))
   })

--- a/R/sql_methods.R
+++ b/R/sql_methods.R
@@ -112,6 +112,8 @@ to_sql <- function(df,
   
   username <- NULL
   password <- NULL
+  index <- reticulate::r_to_py(index)
+  nanoseconds <- reticulate::r_to_py(nanoseconds) 
 
   # reading credentials for establishing connection
   conn_param <- get_credentials(username, password, dbname, schemaname)
@@ -136,7 +138,7 @@ to_sql <- function(df,
   arrow::write_feather(df, tf)
   
   tryCatch({
-    reticulate::py_run_string(paste("import pandas as pd;from nuvolos import to_sql;df = pd.read_feather('", tf, "');to_sql(df, ", "'", name, "'", ", database = ","'", dbname,"'", ", schema = ", "'", schemaname, "'", ", if_exists = 'replace', index = False, con = con)",  sep = ""))
+    reticulate::py_run_string(paste("import pandas as pd;from nuvolos import to_sql;df = pd.read_feather('", tf, "');to_sql(df, ", "'", name, "'", ", database = ","'", dbname,"'", ", schema = ", "'", schemaname, "'", ", if_exists = ", "'", if_exists, "'", ", index = ", index, ", nanoseconds =", nanoseconds, ", con = con)",  sep = ""))
   }, finally = {
     reticulate::py_run_string("con.close()")
     reticulate::py_run_string("engine.dispose()")

--- a/R/sql_methods.R
+++ b/R/sql_methods.R
@@ -136,7 +136,7 @@ to_sql <- function(df,
   arrow::write_feather(df, tf)
   
   tryCatch({
-    reticulate::py_run_string(paste("import pandas as pd;from nuvolos import to_sql;df = pd.read_feather('", tf, "');to_sql(df, ", "'", name, "'", ", database = ","'", dbname,"'", ", schema = ", "'", schemaname, "'", ", if_exists = ", "'", if_exists, "'", ", index = ", index, ", nanoseconds =", nanoseconds, ", con = con)",  sep = ""))
+    reticulate::py_run_string(paste("import pandas as pd;from nuvolos import to_sql;df = pd.read_feather('", tf, "');to_sql(df, ", "'", name, "'", ", database = ","'", dbname,"'", ", schema = ", "'", schemaname, "'", ", if_exists = 'replace', index = False, con = con)",  sep = ""))
   }, finally = {
     reticulate::py_run_string("con.close()")
     reticulate::py_run_string("engine.dispose()")


### PR DESCRIPTION
This branch contains the following: 
1) Correction of to_sql variable usage (default values were set in the code without being able to overwrite, now corrected) https://3.basecamp.com/3994369/buckets/15554446/todos/4011059412

2) The solution for miniconda installer prompt not showing (@matek-alphacruncher's PR). It is just an issue in case of Nuvolos, working fine on local computer. This is because the RStudio handles environment variables differently on Nuvolos, and cannot find them in the global environment, but reticulate requires to have a variable set as true to show the prompt.

In terms of code, the Sys.getenv("RETICULATE_MINICONDA_ENABLED", unset = "TRUE") is used by reticulate in their function, but on Nuvolos, the value of the env var after the above statement is still false. My solution is to check the value of this variable before py_install(nuvolos) and set it true so when it notices there is no miniconda, it asks the user to install it. I checked the above code in a dirrefent space with no miniconda, and worked fine.